### PR TITLE
fix: safe destroy of hcaptcha instance

### DIFF
--- a/projects/ng-hcaptcha/src/lib/ng-hcaptcha-invisible-button.directive.ts
+++ b/projects/ng-hcaptcha/src/lib/ng-hcaptcha-invisible-button.directive.ts
@@ -59,6 +59,10 @@ export class NgHcaptchaInvisibleButtonDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    if (this.widgetId) {
+      window.hcaptcha.remove(this.widgetId);
+    }
+
     if (isPlatformServer(this.platformId)) {
       return;
     }

--- a/projects/ng-hcaptcha/src/lib/ng-hcaptcha.component.ts
+++ b/projects/ng-hcaptcha/src/lib/ng-hcaptcha.component.ts
@@ -99,6 +99,10 @@ export class NgHcaptchaComponent implements OnInit, OnDestroy, ControlValueAcces
   }
 
   ngOnDestroy() {
+    if (this.widgetId) {
+      window.hcaptcha.remove(this.widgetId);
+    }
+
     if (isPlatformServer(this.platformId)) {
       return;
     }


### PR DESCRIPTION
* for a safe cleanup it is recommended to use `hcaptcha.remove(hCaptchaId)`